### PR TITLE
Initialize Alert object by calling alert.text

### DIFF
--- a/py/selenium/webdriver/remote/switch_to.py
+++ b/py/selenium/webdriver/remote/switch_to.py
@@ -40,7 +40,9 @@ class SwitchTo:
         :Usage:
             alert = driver.switch_to.alert
         """
-        return Alert(self._driver)
+        alert = Alert(self._driver)
+        alert.text
+        return alert
 
     def default_content(self):
         """


### PR DESCRIPTION
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

this is how it's done in the Java client, and makes sense as you would want to fail, or have your alert reference as early as possible.

Fixes #1822